### PR TITLE
Feat: AnalysisRun 단일 상세 조회 API 구현 (권한 검증 포함)

### DIFF
--- a/backend/src/main/java/com/aicollab/backend/analysis/controller/AnalysisRunController.java
+++ b/backend/src/main/java/com/aicollab/backend/analysis/controller/AnalysisRunController.java
@@ -1,0 +1,31 @@
+package com.aicollab.backend.analysis.controller;
+
+import com.aicollab.backend.analysis.dto.response.AnalysisRunResponse;
+import com.aicollab.backend.analysis.service.AnalysisRunQueryService;
+import com.aicollab.backend.auth.security.UserPrincipal;
+import com.aicollab.backend.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/analysis-runs/")
+public class AnalysisRunController {
+
+    private final AnalysisRunQueryService analysisRunQueryService;
+
+    @GetMapping("/{runId}")
+    public ApiResponse<AnalysisRunResponse> getAnalysisRun(
+            @PathVariable Long runId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        AnalysisRunResponse response =
+                analysisRunQueryService.getById(runId, principal.getId());
+
+        return ApiResponse.success(response);
+    }
+}

--- a/backend/src/main/java/com/aicollab/backend/analysis/service/AnalysisRunQueryService.java
+++ b/backend/src/main/java/com/aicollab/backend/analysis/service/AnalysisRunQueryService.java
@@ -1,0 +1,30 @@
+package com.aicollab.backend.analysis.service;
+
+import com.aicollab.backend.analysis.domain.AnalysisRun;
+import com.aicollab.backend.analysis.dto.response.AnalysisRunResponse;
+import com.aicollab.backend.analysis.repository.AnalysisRunRepository;
+import com.aicollab.backend.upload.domain.Upload;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AnalysisRunQueryService {
+
+    private final AnalysisRunRepository analysisRunRepository;
+
+    public AnalysisRunResponse getById(Long runId, Long requesterId) {
+
+        AnalysisRun run = analysisRunRepository.findById(runId)
+                .orElseThrow(() -> new IllegalArgumentException("AnalysisRun not found"));
+
+        Upload upload = run.getUpload();
+
+        // 권한 검증 (업로드 owner만 조회 가능)
+        if (!upload.getProject().getOwner().getId().equals(requesterId)) {
+            throw new IllegalArgumentException("Not allowed to view this analysis run");
+        }
+
+        return AnalysisRunResponse.from(run);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
#18 

## 📝 작업 내용
- AnalysisRun 단일 조회 서비스 메서드 구현
- 권한 체크: 업로드의 owner만 조회 가능하도록 설정
- 예외 처리: 없는 ID 조회 시 404 처리