### PR TITLE
✨ Feat: 프로젝트 삭제 기능 추가 및 예외 처리 구조 정비

### DIFF
--- a/backend/src/main/java/com/aicollab/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/aicollab/backend/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.aicollab.backend.global.exception;
 
 import com.aicollab.backend.global.response.ApiResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -32,5 +33,12 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())
                 .body(body);
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ApiResponse<?>> handleIllegalState(IllegalStateException ex) {
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)   // 409
+                .body(ApiResponse.error("409",ex.getMessage()));
     }
 }

--- a/backend/src/main/java/com/aicollab/backend/project/service/ProjectService.java
+++ b/backend/src/main/java/com/aicollab/backend/project/service/ProjectService.java
@@ -4,6 +4,7 @@ import com.aicollab.backend.project.domain.Project;
 import com.aicollab.backend.project.dto.request.ProjectCreateRequest;
 import com.aicollab.backend.project.dto.response.ProjectResponse;
 import com.aicollab.backend.project.repository.ProjectRepository;
+import com.aicollab.backend.upload.repository.UploadRepository;
 import com.aicollab.backend.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,6 +16,7 @@ import java.util.List;
 public class ProjectService {
 
     private final ProjectRepository projectRepository;
+    private final UploadRepository uploadRepository;
 
     // 프로젝트 생성
     public Project create(ProjectCreateRequest req, User owner) {
@@ -66,6 +68,11 @@ public class ProjectService {
 
         if(!project.getOwner().getId().equals(requester.getId())) {
             throw new IllegalArgumentException("Only the owner can delete this project");
+        }
+
+        long uploadCount = uploadRepository.countByProjectId(id);
+        if (uploadCount > 0) {
+            throw new IllegalStateException("프로젝트에 연결된 업로드 내역이 있어 삭제할 수 없습니다.");
         }
 
         projectRepository.delete(project);

--- a/backend/src/main/java/com/aicollab/backend/upload/repository/UploadRepository.java
+++ b/backend/src/main/java/com/aicollab/backend/upload/repository/UploadRepository.java
@@ -4,4 +4,5 @@ import com.aicollab.backend.upload.domain.Upload;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UploadRepository extends JpaRepository<Upload, Long> {
+    long countByProjectId(Long projectId);
 }

--- a/frontend/src/pages/projects/ProjectDetail.tsx
+++ b/frontend/src/pages/projects/ProjectDetail.tsx
@@ -50,6 +50,25 @@ export default function ProjectDetail() {
       .finally(() => setLoading(false));
   }, [id]);
 
+    const deleteProject = async () => {
+    const ok = window.confirm("정말 삭제하시겠습니까?");
+    if (!ok) return;
+
+    try {
+      await api.delete(`/api/projects/${id}`);
+      alert("프로젝트가 삭제되었습니다.");
+      navigate("/");
+    } catch (err: any) {
+        console.error(err);
+
+        const message =
+          err.response?.data?.message ||
+          "삭제에 실패했습니다.";
+
+        alert(message);
+      }
+  };
+
   if (loading)
     return (
       <div className="fullscreen-loading">
@@ -63,8 +82,10 @@ export default function ProjectDetail() {
   return (
     <div className="project-detail-container">
       <div className="project-header">
-        <h2>{project.name}</h2>
-        <p className="description">{project.description}</p>
+        <div className="project-info">
+          <h2>{project.name}</h2>
+          <p className="description">{project.description}</p>
+        </div>
 
         <a
           className="repo-link"
@@ -101,6 +122,7 @@ export default function ProjectDetail() {
           </li>
         ))}
       </ul>
+      <button className="delete-btn" onClick={deleteProject}>Delete</button>
     </div>
   );
 }

--- a/frontend/src/styles/ProjectDetail.scss
+++ b/frontend/src/styles/ProjectDetail.scss
@@ -6,21 +6,29 @@
 }
 
 .project-header {
-  margin-bottom: 30px;
+  margin-bottom: 55px;
   display: flex;
   justify-content: space-between;
   align-items: center;
+
+  .project-info{
+    display: flex;
+    align-items: flex-end;
+    gap: 10px;
+  }
 
   h2 {
     font-size: 24px;
     font-weight: 600;
     color: #222;
+    margin-bottom: 0;
   }
 
   .description {
     font-size: 14px;
     color: #666;
     line-height: 1.5;
+    max-width: 50%;
   }
 }
 
@@ -123,6 +131,29 @@
 
   &:hover {
     background: #000;
+  }
+}
+
+.header-actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 10px;
+}
+
+.delete-btn {
+  padding: 8px 12px;
+  background: #e74c3c;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-size: 14px;
+  display: block;
+  margin: 20px 0 0 auto;
+  cursor: pointer;
+  transition: 0.2s;
+
+  &:hover {
+    background: #c0392b;
   }
 }
 


### PR DESCRIPTION
## 📌 관련 이슈
#30 #35 

## 📝 작업 내용
🔨백엔드
- 프로젝트 삭제 시 FK 제약(uploads 존재 여부)을 사전 검증하도록 로직 추가
- IllegalStateException을 409(CONFLICT)로 매핑
- GlobalExceptionHandler에 관련 핸들러 추가

🔨프론트
- 프로젝트 상세 페이지에 삭제 기능 추가
- 백엔드에서 내려주는 에러 메시지를 그대로 alert로 표시하도록 수정
- 삭제 후 프로젝트 목록 페이지로 이동 처리 보완